### PR TITLE
Fix: Remove onInput abstraction in InputText

### DIFF
--- a/src/components/Inputs/CorInputMoney/CorInputMoney.types.ts
+++ b/src/components/Inputs/CorInputMoney/CorInputMoney.types.ts
@@ -1,11 +1,12 @@
 import { VNode } from 'vue';
 import { CorInputTextProps } from '../CorInputText/CorInputText.types';
 
-export interface CorInputMoneyProps extends CorInputTextProps {
+export interface CorInputMoneyProps extends Omit<CorInputTextProps, 'onChange'> {
     symbol?: string | VNode;
     symbolPosition?: 'left' | 'right';
     max?: number;
     min?: number;
     decimals?: number;
     step?: number;
+    onChange: (value: string) => void;
 }

--- a/src/components/Inputs/CorInputText/CorInputText.tsx
+++ b/src/components/Inputs/CorInputText/CorInputText.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames';
-import { FunctionalComponent, ref } from 'vue';
+import { FunctionalComponent } from 'vue';
 import CSS from './CorInputText.module.scss';
 import { CorInputTextProps } from './CorInputText.types';
 
@@ -23,12 +23,6 @@ const CorInputText: FunctionalComponent<CorInputTextProps> = ({
         [CSS['cor_input_text--error']]: status === 'error',
     });
 
-    const onInput = (e: Event) => {
-        if (!onChange) return;
-        const inputElement = e.target as HTMLInputElement;
-        onChange(inputElement.value);
-    };
-
     return (
         <div class={classes}>
             {label && <label>{label}</label>}
@@ -40,7 +34,7 @@ const CorInputText: FunctionalComponent<CorInputTextProps> = ({
                 maxlength={maxLength}
                 minlength={minLength}
                 type="text"
-                onInput={onInput}
+                onInput={onChange}
                 onBlur={onBlur}
                 onSubmit={onSubmit}
                 onKeydown={onKeydown}

--- a/src/components/Inputs/CorInputText/CorInputText.types.ts
+++ b/src/components/Inputs/CorInputText/CorInputText.types.ts
@@ -10,7 +10,7 @@ export interface CorInputTextProps extends CorInputProps {
     minLength?: number;
     placeholder?: string;
     status?: 'success' | 'warning' | 'error' | undefined;
-    onChange?: (value: string) => void;
+    onChange?: (event: Event) => void;
     onBlur?: (event: FocusEvent) => void;
     onKeydown?: (event: KeyboardEvent) => void;
 }

--- a/src/components/Inputs/Input.types.ts
+++ b/src/components/Inputs/Input.types.ts
@@ -6,7 +6,7 @@ export interface CorInputProps<T = string> {
     placeholder?: string;
     status?: 'success' | 'warning' | 'error' | undefined;
     clases?: string | string[];
-    onChange?(value: string): void;
+    onChange?(value: string | Event): void;
     onSubmit?(e: Event): void;
     onBlur?(e: FocusEvent): void;
     onKeydown?(e: KeyboardEvent): void;


### PR DESCRIPTION
# Description

We may need to use the event object instead of string via onInput.
Thus, we need to remove the onInput abstraction in InputText.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refacto 
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentantion 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules