### PR TITLE
feat: Add InputText variant prop

### DIFF
--- a/src/components/Inputs/CorInputMoney/CorInputMoney.types.ts
+++ b/src/components/Inputs/CorInputMoney/CorInputMoney.types.ts
@@ -1,7 +1,7 @@
 import { VNode } from 'vue';
 import { CorInputTextProps } from '../CorInputText/CorInputText.types';
 
-export interface CorInputMoneyProps extends Omit<CorInputTextProps, 'onChange'> {
+export interface CorInputMoneyProps extends Omit<CorInputTextProps, 'onChange' | 'variant'> {
     symbol?: string | VNode;
     symbolPosition?: 'left' | 'right';
     max?: number;

--- a/src/components/Inputs/CorInputText/CorInputText.stories.mdx
+++ b/src/components/Inputs/CorInputText/CorInputText.stories.mdx
@@ -122,7 +122,8 @@ A `CorInputText` allows the user to specify a text.
 | maxLength | number | undefined, **default**: undefined  |
 | minLength | number | undefined, **default**: undefined  |
 | placeholder | string | undefined, **default**: undefined  |
-| status | string: 'success' | 'warning' | 'error' | undefined, **default**: undefined  |
+| status | string: 'success' \| 'warning' \| 'error' \| undefined, **default**: undefined  |
+| variant | string: 'text' \| 'password' \| 'email', **default**: 'text'  |
 | onChange | (value: string) => void | undefined, **default**: undefined  |
 | onBlur | (value: FocusEvent) => void | undefined, **default**: undefined  |
 | onKeydown | (value: KeyboardEvent) => void | undefined, **default**: undefined  |

--- a/src/components/Inputs/CorInputText/CorInputText.stories.tsx
+++ b/src/components/Inputs/CorInputText/CorInputText.stories.tsx
@@ -12,6 +12,7 @@ export default {
         value: { type: 'string' },
         status: { control: 'select', options: ['success', 'warning', 'error', undefined] },
         statusMessage: { type: 'string' },
+        variant: { control: 'select', options: ['text', 'password', 'email'] },
         onChange: { action: 'onChange' },
         onSubmit: { action: 'onSubmit' },
     },
@@ -29,6 +30,7 @@ export const Default = Template.bind({});
 Default.args = {
     label: 'Label',
     disabled: false,
+    variant: 'text',
     placeholder: 'Placeholder',
 };
 
@@ -36,6 +38,7 @@ export const Disabled = Template.bind({});
 Disabled.args = {
     label: 'Disabled text input',
     disabled: true,
+    variant: 'text',
     value: 'Not editable',
 };
 
@@ -45,5 +48,6 @@ ErrorWithMessage.args = {
     disabled: false,
     status: 'error',
     statusMessage: 'This is an error message',
+    variant: 'text',
     value: 'Wrong value',
 };

--- a/src/components/Inputs/CorInputText/CorInputText.tsx
+++ b/src/components/Inputs/CorInputText/CorInputText.tsx
@@ -12,6 +12,7 @@ const CorInputText: FunctionalComponent<CorInputTextProps> = ({
     placeholder,
     value,
     status,
+    variant = 'text',
     onBlur,
     onChange,
     onSubmit,
@@ -33,7 +34,7 @@ const CorInputText: FunctionalComponent<CorInputTextProps> = ({
                 placeholder={placeholder}
                 maxlength={maxLength}
                 minlength={minLength}
-                type="text"
+                type={variant}
                 onInput={onChange}
                 onBlur={onBlur}
                 onSubmit={onSubmit}

--- a/src/components/Inputs/CorInputText/CorInputText.types.ts
+++ b/src/components/Inputs/CorInputText/CorInputText.types.ts
@@ -10,6 +10,7 @@ export interface CorInputTextProps extends CorInputProps {
     minLength?: number;
     placeholder?: string;
     status?: 'success' | 'warning' | 'error' | undefined;
+    variant?: 'text' | 'password' | 'email';
     onChange?: (event: Event) => void;
     onBlur?: (event: FocusEvent) => void;
     onKeydown?: (event: KeyboardEvent) => void;


### PR DESCRIPTION
# Description

Since an input text can also be a password or an email, we need to add a new prop called variant to switch between text, password, and email inputs.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Storybook

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules