### PR TITLE
Fix: Set base type of input props to HTMLInputElement

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request.md
@@ -9,15 +9,14 @@ Fixes # (issue)
 Please delete options that are not relevant.
 
 - [ ] Bug fix (non-breaking change which fixes an issue)
-- [ ] Refacto 
+- [ ] Refacto
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-- [ ] Documentantion 
+- [ ] Documentation
 
 # How Has This Been Tested?
 
 Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-
 
 # Checklist:
 

--- a/src/components/Inputs/Input.types.ts
+++ b/src/components/Inputs/Input.types.ts
@@ -1,4 +1,12 @@
-export interface CorInputProps<T = string> {
+type TypeOmitHTMLInput = Omit<HTMLInputElement, 'value' | 'max' | 'min' | 'step'>;
+type HTMLInputProps<T> = Partial<TypeOmitHTMLInput> & {
+    value?: T;
+    min?: number;
+    max?: number;
+    step?: number;
+};
+
+export interface CorInputProps<T = string> extends HTMLInputProps<T> {
     value?: T;
     disabled?: boolean;
     label?: string;


### PR DESCRIPTION
# Description

In order to expose all HTML Input props, we use HTMLInputElement type and extend it for our inputs

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refacto

# How Has This Been Tested?

Storybook

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules