### PR TITLE
Fix: use a if instead of optional chaining

### DIFF
--- a/src/components/Inputs/CorInputCheckbox/CorInputCheckbox.tsx
+++ b/src/components/Inputs/CorInputCheckbox/CorInputCheckbox.tsx
@@ -32,7 +32,9 @@ const CorInputCheckbox = defineComponent({
 
         const onChange = (e: Event) => {
             state.value = !state.value;
-            props.onChange?.(e);
+            if (props.onChange) {
+                props.onChange(e);
+            }
         };
 
         return () => (


### PR DESCRIPTION
# Description

Because of a problem with Vite, optional chaining is not working.
While we find a solution, here's a quick fix.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules