### PR TITLE
Fix: add classname in inputs

### DIFF
--- a/src/components/Inputs/CorInputText/CorInputText.tsx
+++ b/src/components/Inputs/CorInputText/CorInputText.tsx
@@ -12,13 +12,14 @@ const CorInputText: FunctionalComponent<CorInputTextProps> = ({
     placeholder,
     value,
     status,
+    className = '',
     variant = 'text',
     onBlur,
     onChange,
     onSubmit,
     onKeydown,
 }) => {
-    const classes = classNames(CSS.cor_input_text, {
+    const classes = classNames(CSS.cor_input_text, className, {
         [CSS['cor_input_text--success']]: status === 'success',
         [CSS['cor_input_text--warning']]: status === 'warning',
         [CSS['cor_input_text--error']]: status === 'error',

--- a/src/components/Inputs/CorInputText/CorInputText.types.ts
+++ b/src/components/Inputs/CorInputText/CorInputText.types.ts
@@ -5,7 +5,7 @@ export interface CorInputTextProps extends CorInputProps {
     disabled?: boolean;
     label?: string;
     statusMessage?: string;
-    class?: string;
+    className?: string;
     maxLength?: number;
     minLength?: number;
     placeholder?: string;

--- a/src/components/Inputs/CorTextarea/CorTextarea.tsx
+++ b/src/components/Inputs/CorTextarea/CorTextarea.tsx
@@ -12,10 +12,11 @@ const CorTextarea: FunctionalComponent<CorTextareaProps> = ({
     placeholder,
     value,
     status,
+    className,
     onChange,
     onSubmit,
 }) => {
-    const classes = classNames(CSS.cor_textarea, {
+    const classes = classNames(CSS.cor_textarea, className, {
         [CSS['cor_textarea--success']]: status === 'success',
         [CSS['cor_textarea--warning']]: status === 'warning',
         [CSS['cor_textarea--error']]: status === 'error',

--- a/src/components/Inputs/CorTextarea/CorTextarea.types.ts
+++ b/src/components/Inputs/CorTextarea/CorTextarea.types.ts
@@ -7,6 +7,7 @@ export interface CorTextareaProps {
     minLength?: number;
     placeholder?: string;
     status?: 'success' | 'warning' | 'error' | undefined;
+    className: string;
     onChange?(value: string): void;
     onSubmit?(e: Event): void;
 }

--- a/src/components/Inputs/Input.types.ts
+++ b/src/components/Inputs/Input.types.ts
@@ -13,7 +13,7 @@ export interface CorInputProps<T = string> extends HTMLInputProps<T> {
     statusMessage?: string;
     placeholder?: string;
     status?: 'success' | 'warning' | 'error' | undefined;
-    class?: string | string[];
+    className?: string;
     onChange?(value: string | Event): void;
     onSubmit?(e: Event): void;
     onBlur?(e: FocusEvent): void;


### PR DESCRIPTION
# Description

For override purpose, adding className into the classNames object of InputText and TextArea

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refacto
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules