### PR TITLE
Fix: add inputClassName and textareaClassName props

### DIFF
--- a/src/components/Inputs/CorInputText/CorInputText.tsx
+++ b/src/components/Inputs/CorInputText/CorInputText.tsx
@@ -14,6 +14,7 @@ const CorInputText: FunctionalComponent<CorInputTextProps> = ({
     status,
     className = '',
     variant = 'text',
+    inputClassName,
     onBlur,
     onChange,
     onSubmit,
@@ -40,6 +41,7 @@ const CorInputText: FunctionalComponent<CorInputTextProps> = ({
                 onBlur={onBlur}
                 onSubmit={onSubmit}
                 onKeydown={onKeydown}
+                class={inputClassName}
             />
             {statusMessage && <div class={CSS.cor_input_text__status}>{statusMessage}</div>}
         </div>

--- a/src/components/Inputs/CorTextarea/CorTextarea.tsx
+++ b/src/components/Inputs/CorTextarea/CorTextarea.tsx
@@ -13,6 +13,7 @@ const CorTextarea: FunctionalComponent<CorTextareaProps> = ({
     value,
     status,
     className,
+    textareaClassName,
     onChange,
     onSubmit,
 }) => {
@@ -40,6 +41,7 @@ const CorTextarea: FunctionalComponent<CorTextareaProps> = ({
                 minlength={minLength}
                 onInput={onInput}
                 onSubmit={onSubmit}
+                class={textareaClassName}
             />
             {statusMessage && <div class={CSS.cor_textarea__status}>{statusMessage}</div>}
         </div>

--- a/src/components/Inputs/CorTextarea/CorTextarea.types.ts
+++ b/src/components/Inputs/CorTextarea/CorTextarea.types.ts
@@ -8,6 +8,7 @@ export interface CorTextareaProps {
     placeholder?: string;
     status?: 'success' | 'warning' | 'error' | undefined;
     className: string;
+    textareaClassName?: string;
     onChange?(value: string): void;
     onSubmit?(e: Event): void;
 }

--- a/src/components/Inputs/Input.types.ts
+++ b/src/components/Inputs/Input.types.ts
@@ -14,6 +14,7 @@ export interface CorInputProps<T = string> extends HTMLInputProps<T> {
     placeholder?: string;
     status?: 'success' | 'warning' | 'error' | undefined;
     className?: string;
+    inputClassName?: string;
     onChange?(value: string | Event): void;
     onSubmit?(e: Event): void;
     onBlur?(e: FocusEvent): void;


### PR DESCRIPTION
# Description

Add a prop to add a class directly to inputs and textareas in InputText and InputTextarea

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refacto
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules