### PR TITLE
Feat: Add closeOnBlur to Modal (COR-NA)

### DIFF
--- a/src/components/Modal/CorModal/CorModal.tsx
+++ b/src/components/Modal/CorModal/CorModal.tsx
@@ -14,6 +14,7 @@ const CorModal: FunctionalComponent<CorModalProps> = (
         state,
         escKeyClose = false,
         closeOnFocusOut = false,
+        closeOnBlur = false,
         open = false,
         onEnter = () => null,
         onLeave = () => null,
@@ -64,6 +65,7 @@ const CorModal: FunctionalComponent<CorModalProps> = (
                             class={classesContainer}
                             ref={modalContainer}
                             onFocusout={() => closeOnFocusOut && close()}
+                            onBlur={() => closeOnBlur && close()}
                             onKeydown={(e) => {
                                 handleCloseEscKey({
                                     e,

--- a/src/components/Modal/CorModal/CorModal.type.ts
+++ b/src/components/Modal/CorModal/CorModal.type.ts
@@ -9,6 +9,7 @@ export interface CorModalProps {
     open?: boolean;
     escKeyClose?: boolean;
     closeOnFocusOut?: boolean;
+    closeOnBlur?: boolean;
     onEnter?: (e: Element, done: () => void) => void;
     onLeave?: (e: Element, done: () => void) => void;
 }

--- a/src/components/Modal/CorModal/Modal.stories.tsx
+++ b/src/components/Modal/CorModal/Modal.stories.tsx
@@ -33,7 +33,7 @@ const Template: StoryFn<CorModalProps> = (args) => {
     return (
         <div>
             <Button callback={() => handlerOpen.open()} title={'open modal'} />
-            <CorModal v-bind={args} id={modalId} state={firstModal.value}>
+            <CorModal {...args} id={modalId} state={firstModal.value}>
                 <ModalContainer
                     title="this is an example of simple Modal"
                     callback={() => handlerOpen.close()}
@@ -43,8 +43,10 @@ const Template: StoryFn<CorModalProps> = (args) => {
     );
 };
 export const ModalStory = Template.bind({});
+
 ModalStory.args = {
-    closeOnFocusOut: true,
+    closeOnFocusOut: false,
+    closeOnBlur: true,
     escKeyClose: false,
 };
 
@@ -67,8 +69,13 @@ const doubleModal: StoryFn<{ Modal1: CorModalProps; Modal2: CorModalProps }> = (
                     state={firstModalState.value}
                     v-bind={args.Modal1}
                     id={firstModal}
+                    closeOnFocusOut
                     v-slots={() => (
-                        <ModalContainer title="example Modal 1" ref={firstModal} callback={close} />
+                        <ModalContainer
+                            title="example Modal 1 closeOnFocusOut"
+                            ref={firstModal}
+                            callback={close}
+                        />
                     )}
                 />
                 <br />
@@ -77,9 +84,10 @@ const doubleModal: StoryFn<{ Modal1: CorModalProps; Modal2: CorModalProps }> = (
                     state={modalState.value}
                     v-bind={args.Modal2}
                     id={secondModal}
+                    closeOnBlur
                     v-slots={() => (
                         <ModalContainer
-                            title="Example Modal 2"
+                            title="Example Modal 2 closeOnBlur"
                             ref={secondModal}
                             callback={handlerSecondModal.close}
                         />
@@ -91,13 +99,3 @@ const doubleModal: StoryFn<{ Modal1: CorModalProps; Modal2: CorModalProps }> = (
 };
 
 export const Doublemodal = doubleModal.bind({});
-Doublemodal.args = {
-    Moda1: {
-        closeOnFocusOut: true,
-        escKeyClose: false,
-    },
-    Modal2: {
-        closeOnFocusOut: true,
-        escKeyClose: false,
-    },
-};


### PR DESCRIPTION
# Description

Adds `closeOnBlur` prop to Modal, I did this because when you use `onFocusout` if you have an input element inside and it gets focused, it will close the modal. (`onfocusout` is triggered on the element and its childs, if you have interaction within your modal you dont want that, you want `onblur`)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refacto
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
