### PR TITLE
Fix: Modal onfocusout & revert Modal closeOnBlur (COR-NA)

### DIFF
--- a/src/components/Modal/CorModal/CorModal.tsx
+++ b/src/components/Modal/CorModal/CorModal.tsx
@@ -63,7 +63,12 @@ const CorModal: FunctionalComponent<CorModalProps> = (
                             tabindex="1"
                             class={classesContainer}
                             ref={modalContainer}
-                            onFocusout={() => closeOnFocusOut && close()}
+                            onFocusout={(e) => {
+                                const leavingParent = !(e.currentTarget as Node)?.contains(
+                                    e.relatedTarget as Node
+                                );
+                                if (leavingParent && closeOnFocusOut) close();
+                            }}
                             onKeydown={(e) => {
                                 handleCloseEscKey({
                                     e,

--- a/src/components/Modal/CorModal/CorModal.tsx
+++ b/src/components/Modal/CorModal/CorModal.tsx
@@ -14,7 +14,6 @@ const CorModal: FunctionalComponent<CorModalProps> = (
         state,
         escKeyClose = false,
         closeOnFocusOut = false,
-        closeOnBlur = false,
         open = false,
         onEnter = () => null,
         onLeave = () => null,
@@ -65,7 +64,6 @@ const CorModal: FunctionalComponent<CorModalProps> = (
                             class={classesContainer}
                             ref={modalContainer}
                             onFocusout={() => closeOnFocusOut && close()}
-                            onBlur={() => closeOnBlur && close()}
                             onKeydown={(e) => {
                                 handleCloseEscKey({
                                     e,

--- a/src/components/Modal/CorModal/CorModal.type.ts
+++ b/src/components/Modal/CorModal/CorModal.type.ts
@@ -9,7 +9,6 @@ export interface CorModalProps {
     open?: boolean;
     escKeyClose?: boolean;
     closeOnFocusOut?: boolean;
-    closeOnBlur?: boolean;
     onEnter?: (e: Element, done: () => void) => void;
     onLeave?: (e: Element, done: () => void) => void;
 }

--- a/src/components/Modal/CorModal/Modal.stories.tsx
+++ b/src/components/Modal/CorModal/Modal.stories.tsx
@@ -33,7 +33,7 @@ const Template: StoryFn<CorModalProps> = (args) => {
     return (
         <div>
             <Button callback={() => handlerOpen.open()} title={'open modal'} />
-            <CorModal v-bind={args} id={modalId} state={firstModal.value}>
+            <CorModal {...args} id={modalId} state={firstModal.value}>
                 <ModalContainer
                     title="this is an example of simple Modal"
                     callback={() => handlerOpen.close()}
@@ -64,22 +64,27 @@ const doubleModal: StoryFn<{ Modal1: CorModalProps; Modal2: CorModalProps }> = (
             <div>
                 <Button title={'open Modal 1'} callback={open} />
                 <CorModal
+                    closeOnFocusOut
                     state={firstModalState.value}
                     v-bind={args.Modal1}
                     id={firstModal}
                     v-slots={() => (
-                        <ModalContainer title="example Modal 1" ref={firstModal} callback={close} />
+                        <ModalContainer
+                            title="close onFocusout"
+                            ref={firstModal}
+                            callback={close}
+                        />
                     )}
                 />
                 <br />
                 <Button title={'open Modal 2'} callback={handlerSecondModal.open} />
                 <CorModal
+                    escKeyClose
                     state={modalState.value}
-                    v-bind={args.Modal2}
                     id={secondModal}
                     v-slots={() => (
                         <ModalContainer
-                            title="Example Modal 2"
+                            title="close onEscapePressed"
                             ref={secondModal}
                             callback={handlerSecondModal.close}
                         />
@@ -91,13 +96,3 @@ const doubleModal: StoryFn<{ Modal1: CorModalProps; Modal2: CorModalProps }> = (
 };
 
 export const Doublemodal = doubleModal.bind({});
-Doublemodal.args = {
-    Moda1: {
-        closeOnFocusOut: true,
-        escKeyClose: false,
-    },
-    Modal2: {
-        closeOnFocusOut: true,
-        escKeyClose: false,
-    },
-};

--- a/src/components/Modal/CorModal/Modal.stories.tsx
+++ b/src/components/Modal/CorModal/Modal.stories.tsx
@@ -33,7 +33,7 @@ const Template: StoryFn<CorModalProps> = (args) => {
     return (
         <div>
             <Button callback={() => handlerOpen.open()} title={'open modal'} />
-            <CorModal {...args} id={modalId} state={firstModal.value}>
+            <CorModal v-bind={args} id={modalId} state={firstModal.value}>
                 <ModalContainer
                     title="this is an example of simple Modal"
                     callback={() => handlerOpen.close()}
@@ -43,10 +43,8 @@ const Template: StoryFn<CorModalProps> = (args) => {
     );
 };
 export const ModalStory = Template.bind({});
-
 ModalStory.args = {
-    closeOnFocusOut: false,
-    closeOnBlur: true,
+    closeOnFocusOut: true,
     escKeyClose: false,
 };
 
@@ -69,13 +67,8 @@ const doubleModal: StoryFn<{ Modal1: CorModalProps; Modal2: CorModalProps }> = (
                     state={firstModalState.value}
                     v-bind={args.Modal1}
                     id={firstModal}
-                    closeOnFocusOut
                     v-slots={() => (
-                        <ModalContainer
-                            title="example Modal 1 closeOnFocusOut"
-                            ref={firstModal}
-                            callback={close}
-                        />
+                        <ModalContainer title="example Modal 1" ref={firstModal} callback={close} />
                     )}
                 />
                 <br />
@@ -84,10 +77,9 @@ const doubleModal: StoryFn<{ Modal1: CorModalProps; Modal2: CorModalProps }> = (
                     state={modalState.value}
                     v-bind={args.Modal2}
                     id={secondModal}
-                    closeOnBlur
                     v-slots={() => (
                         <ModalContainer
-                            title="Example Modal 2 closeOnBlur"
+                            title="Example Modal 2"
                             ref={secondModal}
                             callback={handlerSecondModal.close}
                         />
@@ -99,3 +91,13 @@ const doubleModal: StoryFn<{ Modal1: CorModalProps; Modal2: CorModalProps }> = (
 };
 
 export const Doublemodal = doubleModal.bind({});
+Doublemodal.args = {
+    Moda1: {
+        closeOnFocusOut: true,
+        escKeyClose: false,
+    },
+    Modal2: {
+        closeOnFocusOut: true,
+        escKeyClose: false,
+    },
+};


### PR DESCRIPTION
# Description

Reverting closeOnBlur since its useless with this fix. Now closeOnFocusout wont be triggered on focusing childs

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refacto
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
